### PR TITLE
Add GitHub Action to clean up stale preview directories

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -1,0 +1,31 @@
+name: Clean up stale preview directories
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 日本時間の深夜に毎日実行する
+    - cron: "30 18 * * *" 
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove stale preview directories
+        run: |
+          ls -d */ | cut -f1 -d'/' > /tmp/preview_dirs.txt
+          gh pr list --repo GoWorkshopConference/2025 --json number --jq ".[].number" > /tmp/open_prs.txt
+          comm -23 /tmp/preview_dirs.txt /tmp/open_prs.txt | xargs rm -rf
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add -A
+          git commit -m "Remove stale directories"
+          git push origin HEAD:gh-pages


### PR DESCRIPTION
GoWorkshopConference/2025でopenになっていないPRに対応するサブディレクトリを定期的に削除するGitHub Actionを追加します。

PRのclose時にサブディレクトリを削除したほうがシンプルですが、タイミングによっては削除処理の完了前に新しいファイルが追加されてしまう可能性があります。そのため、より安全なこの方法を選んでいます。