### PR TITLE
Set GH_TOKEN for gh command

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -21,6 +21,8 @@ jobs:
           ls -d */ | cut -f1 -d'/' > /tmp/preview_dirs.txt
           gh pr list --repo GoWorkshopConference/2025 --json number --jq ".[].number" > /tmp/open_prs.txt
           comm -23 /tmp/preview_dirs.txt /tmp/open_prs.txt | xargs rm -rf
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
actionの実行時に以下のエラーが出ていたので修正します。

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```